### PR TITLE
Fix build error, update action version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.4.2
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.4.3
 commit = True
 tag = True
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
                   ls dist/
 
             - name: Upload wheel artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: dist-${{ matrix.os }}-${{ matrix.arch }}
                   path: dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,9 +164,10 @@ jobs:
             - name: Upload wheel artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: dist-${{ matrix.os }}-${{ matrix.arch }}
+                  name: dist-${{ matrix.os }}-${{ matrix.arch }}-py${{ matrix.python-version }}
                   path: dist/*.whl
                   retention-days: 1
+                  overwrite: true
 
     publish:
         needs: [check-version, python-package]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
                   pip install uv
 
             - name: Download all artifacts
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   path: dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 
 ---
+## [0.4.3](https://github.com/belingud/gptcomet/compare/v0.4.2..v0.4.3) - 2025-01-24
+
+### 🚜 Refactor
+
+- update command alias in main.go - ([97b25fb](https://github.com/belingud/gptcomet/commit/97b25fb28952d05ed2fa3f0682014eaba61bfbab)) - belingud
+
+### 📚 Documentation
+
+- update CHANGELOG.md for v0.4.2 release and CLI rename - ([d7e7781](https://github.com/belingud/gptcomet/commit/d7e778176edeabc0be929549dbe5a8dfd0ef6cc7)) - belingud
+
+### 🧪 Testing
+
+- update client tests for retry logic and error handling - ([b631e25](https://github.com/belingud/gptcomet/commit/b631e250554c40380dd4bc1a23eb46061030161a)) - belingud
+
+### ⚙️ Miscellaneous Tasks
+
+- update uv lock - ([3755808](https://github.com/belingud/gptcomet/commit/375580834e810e50f6d05d0f0151e5a4cc43bf43)) - belingud
+- upgrade upload-artifact action to v4 in release workflow - ([87bc0f4](https://github.com/belingud/gptcomet/commit/87bc0f40a1a0213a1866b6985b2e47bc0b47479b)) - belingud
+- update uv lock - ([ee286f5](https://github.com/belingud/gptcomet/commit/ee286f531bca45717b728223fdad90d02eaf8d2b)) - belingud
+
+
+---
 ## [0.4.2](https://github.com/belingud/gptcomet/compare/v0.4.1..v0.4.2) - 2025-01-23
 
 ### 🚜 Refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 
 ---
+## [0.4.2](https://github.com/belingud/gptcomet/compare/v0.4.1..v0.4.2) - 2025-01-23
+
+### 🚜 Refactor
+
+- rename CLI command from `gptcomet` to `gmsg` - ([f5079e7](https://github.com/belingud/gptcomet/commit/f5079e7eae640467c8e690668045eb792a561e07)) - belingud
+
+
+---
 ## [0.4.1](https://github.com/belingud/gptcomet/compare/v0.4.0..v0.4.1) - 2025-01-20
 
 ### 🚜 Refactor

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,17 @@
 # Exit script if any command fails
 set -e
 
+# Show usage instructions
+show_usage() {
+    echo "Usage: $0 [-v VERSION]"
+    echo "  -v VERSION  Install specific version (e.g. 0.4.2)"
+    echo
+    echo "Examples:"
+    echo "  $0              # Install latest version"
+    echo "  $0 -v 0.4.2     # Install version 0.4.2"
+    exit 1
+}
+
 # Detect operating system
 detect_os() {
     case "$(uname -s)" in
@@ -33,6 +44,31 @@ detect_arch() {
     esac
 }
 
+# Parse arguments
+VERSION=""
+while getopts ":v:" opt; do
+  case $opt in
+    v)
+      VERSION="$OPTARG"
+      ;;
+    \?)
+      echo "Error: Invalid option -$OPTARG" >&2
+      show_usage
+      ;;
+    :)
+      echo "Error: Option -$OPTARG requires an argument." >&2
+      show_usage
+      ;;
+  esac
+done
+
+# Validate no extra arguments
+shift $((OPTIND-1))
+if [ $# -ne 0 ]; then
+    echo "Error: Unexpected arguments: $@" >&2
+    show_usage
+fi
+
 # Get OS and architecture
 OS=$(detect_os)
 ARCH=$(detect_arch)
@@ -46,18 +82,29 @@ fi
 TMP_DIR=$(mktemp -d)
 cd $TMP_DIR
 
-# Get latest version
-LATEST_VERSION=$(curl -s https://api.github.com/repos/belingud/gptcomet/releases/latest | grep tag_name | cut -d'"' -f4)
-VERSION=${LATEST_VERSION#v} # Remove 'v' prefix
+# Get version
+if [ -z "$VERSION" ]; then
+    # Get latest version if no version specified
+    LATEST_VERSION=$(curl -s https://api.github.com/repos/belingud/gptcomet/releases/latest | grep tag_name | cut -d'"' -f4)
+    VERSION=${LATEST_VERSION#v} # Remove 'v' prefix
+else
+    # Validate specified version exists
+    VERSION=${VERSION#v} # Remove 'v' prefix if present
+    if ! curl -s -o /dev/null -I -w "%{http_code}" https://api.github.com/repos/belingud/gptcomet/releases/tags/v$VERSION | grep -q 200; then
+        echo "Error: Version v$VERSION not found"
+        exit 1
+    fi
+    LATEST_VERSION="v$VERSION"
+fi
 
 # Build download URL based on OS and architecture
 echo "Detected: $OS $ARCH"
 DOWNLOAD_URL="https://github.com/belingud/gptcomet/releases/download/${LATEST_VERSION}/gptcomet_${VERSION}_${OS}_${ARCH}.tar.gz"
 
-# Download latest release
+# Download specified release
 echo "Downloading gptcomet version ${VERSION}..."
 curl -sL "$DOWNLOAD_URL" -o "gptcomet_archive" || {
-    echo "Failed to download from: $DOWNLOAD_URL"
+    echo "Error: Failed to download from: $DOWNLOAD_URL"
     exit 1
 }
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.4.1"
+var version = "0.4.2"
 
 func main() {
 	var (

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	var rootCmd = &cobra.Command{
 		Use:          "gmsg",
-		Aliases:      []string{"gmsg"},
+		Aliases:      []string{"gptcomet"},
 		Short:        "GPTComet - AI-powered Git commit message generator and reviewer",
 		Version:      version,
 		SilenceUsage: true,

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.4.2"
+var version = "0.4.3"
 
 func main() {
 	var (

--- a/main.go
+++ b/main.go
@@ -18,7 +18,8 @@ func main() {
 	)
 
 	var rootCmd = &cobra.Command{
-		Use:          "gptcomet",
+		Use:          "gmsg",
+		Aliases:      []string{"gmsg"},
 		Short:        "GPTComet - AI-powered Git commit message generator and reviewer",
 		Version:      version,
 		SilenceUsage: true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gptcomet"
-version = "0.4.1"
+version = "0.4.2"
 description = "GPTComet: AI-Powered Git Commit Message Generator."
 authors = [{ name = "belingud", email = "im.victor@qq.com" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gptcomet"
-version = "0.4.2"
+version = "0.4.3"
 description = "GPTComet: AI-Powered Git Commit Message Generator."
 authors = [{ name = "belingud", email = "im.victor@qq.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 
 [[package]]
 name = "gptcomet"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 
 [[package]]
 name = "gptcomet"
-version = "0.3.0"
+version = "0.4.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- **refactor: rename CLI command from `gptcomet` to `gmsg`**
- **Bump version: 0.4.1 → 0.4.2**
- **chore: update uv lock**
- **docs: update CHANGELOG.md for v0.4.2 release and CLI rename**
- **test: update client tests for retry logic and error handling**
- **ci: upgrade upload-artifact action to v4 in release workflow**
- **refactor: update command alias in main.go**
- **chore: update uv lock**
- **Bump version: 0.4.2 → 0.4.3**
- **docs: update CHANGELOG.md for v0.4.3 release and related changes**
- **ci: update artifact name and add overwrite option in release workflow**
- **ci: update download-artifact action to v4 in release workflow**
- **feat: add version selection support to install scripts**
