### PR TITLE
Add --no-verify flag to commit cmd

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.1.0
 commit = True
 tag = True
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,13 @@ jobs:
                     - os: macos-14
                       platform: macos
                       arch: arm64
-                    - os: ubuntu-20.04
+                    - os: ubuntu-22.04
                       platform: linux
                       arch: amd64
                     # - os: ubuntu-22.04-arm64
                     #   platform: linux
                     #   arch: arm64
-                os: [windows-latest, macos-13, macos-14, ubuntu-20.04]
+                os: [windows-latest, macos-13, macos-14, ubuntu-22.04]
 
         steps:
             - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 
 ---
+## [2.1.0](https://github.com/belingud/gptcomet/compare/v2.0.0..v2.1.0) - 2025-04-16
+
+### ⛰️  Features
+
+- rename skipHook parameter to noVerify for consistency in CreateCommit method - ([025bab2](https://github.com/belingud/gptcomet/commit/025bab25f6985c9c0b54015a4f7cf729c91f7001)) - belingud
+- update skip-hook flag description for clarity - ([710cad6](https://github.com/belingud/gptcomet/commit/710cad6512b751f6bb9ea9f543bd3867077dd6d2)) - belingud
+- add skip-hook support for git commits and update flag shorthand - ([58c70b1](https://github.com/belingud/gptcomet/commit/58c70b1b345cba710f0bab72b4bb9f876f1cb673)) - belingud
+- add skip git hooks verification flag - ([1dd3261](https://github.com/belingud/gptcomet/commit/1dd32612af5ec403293275852c34bab6a7f4ad6d)) - belingud
+
+### 🐛 Bug Fixes
+
+- remove unused validation function in ReviewOptions - ([d107a50](https://github.com/belingud/gptcomet/commit/d107a5073c34a33d08e5577e272352d722bb142b)) - belingud
+
+### 🚜 Refactor
+
+- Store client config in services, move logging - ([70666df](https://github.com/belingud/gptcomet/commit/70666dfedb0df86052168ac24bc7b1e44a08b25b)) - belingud
+
+### 📚 Documentation
+
+- update README with enhanced project description and features - ([bf5e890](https://github.com/belingud/gptcomet/commit/bf5e8906da32e93451797183559daef396384448)) - belingud
+- update changelog for 2.0.0 release - ([b941a3a](https://github.com/belingud/gptcomet/commit/b941a3a532ae07750b9beb0a794987d971db3c96)) - belingud
+- update CHANGELOG for v2.0.0 release - ([ccc06bf](https://github.com/belingud/gptcomet/commit/ccc06bf3b92ec24872eaae6c9ba72835bc86bac1)) - belingud
+
+### 🧪 Testing
+
+- update CreateCommit noVerify parameter related tests - ([2fb057a](https://github.com/belingud/gptcomet/commit/2fb057a3ede116d9f80bf82d4e0d56cd11b06935)) - belingud
+
+
+---
 ## [2.0.0](https://github.com/belingud/gptcomet/compare/v1.1.1..v2.0.0) - 2025-03-25
 
 Add support for provider config override of command `commit` and `review`.

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ The following are the available commands for GPTComet:
     -   `--svn`: Generate commit message for svn.
     -   `--dry-run`: Dry run the command without actually generating the commit message.
     -   `-y/--yes`: Skip the confirmation prompt.
+    -   `--no-verify`: Skip git hooks verification, akin to using `git commit --no-verify`
     -   `--repo`: Path to the repository (default ".").
     -   `--answer-path`: Override answer path
     -   `--api-base`: Override API base URL

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@
 
 ## 💡 Overview
 
-GPTComet is a go library designed to automate the process of generating commit messages for Git repositories.
-It leverages the power of AI to create meaningful commit messages based on the changes made in the codebase.
+GPTComet is an AI-powered developer tool that streamlines your Git workflow and enhances code quality through automated commit message generation and intelligent code review.
 
 ## ✨ Features
+
+This project leverages the power of large language models to automate repetitive tasks and improve the overall development process. The core features include:
 
 -   **Automatic Commit Message Generation**: GPTComet can generate commit messages based on the changes made in the code.
 -   **Support for Multiple Languages**: GPTComet supports multiple languages, including English, Chinese and so on.

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -35,6 +35,7 @@ type CommitOptions struct {
 	Temperature      float64
 	TopP             float64
 	Provider         string
+	SkipHook         bool
 }
 
 // CommitService handles the logic for committing changes to version control
@@ -334,7 +335,7 @@ func (s *CommitService) handleCommitInteraction(initialMsg string) error {
 // Returns:
 //   - error: nil if successful, otherwise error details with context
 func (s *CommitService) createCommit(msg string) error {
-	err := s.vcs.CreateCommit(s.options.RepoPath, msg)
+	err := s.vcs.CreateCommit(s.options.RepoPath, msg, s.options.SkipHook)
 	if err != nil {
 		return fmt.Errorf("failed to create commit: %w", err)
 	}
@@ -406,6 +407,7 @@ func NewCommitCmd() *cobra.Command {
 	generalFlags.StringVar(&options.RepoPath, "repo", "", "Repository path")
 	generalFlags.BoolVarP(&options.Rich, "rich", "r", false, "Generate rich commit message with details")
 	generalFlags.BoolVarP(&options.AutoYes, "yes", "y", false, "Automatically commit without asking")
+	generalFlags.BoolVarP(&options.SkipHook, "no-verify", "nv", false, "Skip git hooks verification")
 	generalFlags.BoolVar(&options.DryRun, "dry-run", false, "Print the generated commit message and exit without committing")
 	generalFlags.BoolVar(&options.UseSVN, "svn", false, "Use SVN instead of Git")
 

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -35,7 +35,7 @@ type CommitOptions struct {
 	Temperature      float64
 	TopP             float64
 	Provider         string
-	SkipHook         bool
+	NoVerify         bool
 }
 
 // CommitService handles the logic for committing changes to version control
@@ -335,7 +335,7 @@ func (s *CommitService) handleCommitInteraction(initialMsg string) error {
 // Returns:
 //   - error: nil if successful, otherwise error details with context
 func (s *CommitService) createCommit(msg string) error {
-	err := s.vcs.CreateCommit(s.options.RepoPath, msg, s.options.SkipHook)
+	err := s.vcs.CreateCommit(s.options.RepoPath, msg, s.options.NoVerify)
 	if err != nil {
 		return fmt.Errorf("failed to create commit: %w", err)
 	}
@@ -407,7 +407,7 @@ func NewCommitCmd() *cobra.Command {
 	generalFlags.StringVar(&options.RepoPath, "repo", "", "Repository path")
 	generalFlags.BoolVarP(&options.Rich, "rich", "r", false, "Generate rich commit message with details")
 	generalFlags.BoolVarP(&options.AutoYes, "yes", "y", false, "Automatically commit without asking")
-	generalFlags.BoolVar(&options.SkipHook, "no-verify", false, "Skip git hooks verification, akin to using 'git commit --no-verify'")
+	generalFlags.BoolVar(&options.NoVerify, "no-verify", false, "Skip git hooks verification, akin to using 'git commit --no-verify'")
 	generalFlags.BoolVar(&options.DryRun, "dry-run", false, "Print the generated commit message and exit without committing")
 	generalFlags.BoolVar(&options.UseSVN, "svn", false, "Use SVN instead of Git")
 

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -407,7 +407,7 @@ func NewCommitCmd() *cobra.Command {
 	generalFlags.StringVar(&options.RepoPath, "repo", "", "Repository path")
 	generalFlags.BoolVarP(&options.Rich, "rich", "r", false, "Generate rich commit message with details")
 	generalFlags.BoolVarP(&options.AutoYes, "yes", "y", false, "Automatically commit without asking")
-	generalFlags.BoolVarP(&options.SkipHook, "no-verify", "n", false, "Skip git hooks verification")
+	generalFlags.BoolVar(&options.SkipHook, "no-verify", false, "Skip git hooks verification, akin to using 'git commit --no-verify'")
 	generalFlags.BoolVar(&options.DryRun, "dry-run", false, "Print the generated commit message and exit without committing")
 	generalFlags.BoolVar(&options.UseSVN, "svn", false, "Use SVN instead of Git")
 

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -407,7 +407,7 @@ func NewCommitCmd() *cobra.Command {
 	generalFlags.StringVar(&options.RepoPath, "repo", "", "Repository path")
 	generalFlags.BoolVarP(&options.Rich, "rich", "r", false, "Generate rich commit message with details")
 	generalFlags.BoolVarP(&options.AutoYes, "yes", "y", false, "Automatically commit without asking")
-	generalFlags.BoolVarP(&options.SkipHook, "no-verify", "nv", false, "Skip git hooks verification")
+	generalFlags.BoolVarP(&options.SkipHook, "no-verify", "n", false, "Skip git hooks verification")
 	generalFlags.BoolVar(&options.DryRun, "dry-run", false, "Print the generated commit message and exit without committing")
 	generalFlags.BoolVar(&options.UseSVN, "svn", false, "Use SVN instead of Git")
 

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -39,17 +39,6 @@ type ReviewOptions struct {
 	Provider         string
 }
 
-// Validate checks if required fields are set and returns an error if not
-func (o *ReviewOptions) Validate() error {
-	if o.RepoPath == "" {
-		return fmt.Errorf("repository path is required")
-	}
-	if o.ConfigPath == "" {
-		return fmt.Errorf("config path is required")
-	}
-	return nil
-}
-
 // MarkdownRenderer interface for mocking in tests
 type MarkdownRenderer interface {
 	Render(text string, style string) (string, error)

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -124,6 +124,7 @@ func TestReviewService_Execute(t *testing.T) {
 					RepoPath: "test-repo",
 				},
 				markdownRenderer: &GlamourRenderer{},
+				clientConfig:     &types.ClientConfig{Provider: "test-provider", Model: "test-model"},
 			}
 
 			err := service.Execute()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -283,8 +283,13 @@ func (g *GitVCS) GetLastCommitHash(repoPath string) (string, error) {
 //
 // Returns:
 //   - error: An error if the git command fails or if there are issues accessing the repository
-func (g *GitVCS) CreateCommit(repoPath string, message string) error {
-	cmd := exec.Command("git", "commit", "-m", message)
+func (g *GitVCS) CreateCommit(repoPath string, message string, skipHook bool) error {
+	args := []string{"commit", "-m", message}
+	if skipHook {
+		args = append(args, "--no-verify")
+	}
+	debug.Printf("Creating commit with args: %v", args)
+	cmd := exec.Command("git", args...)
 	_, err := g.runCommand(cmd, repoPath)
 	return err
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -280,12 +280,13 @@ func (g *GitVCS) GetLastCommitHash(repoPath string) (string, error) {
 // Parameters:
 //   - repoPath: The file system path to the git repository
 //   - message: The commit message
+//   - noVerify: Whether to skip git hooks verification
 //
 // Returns:
 //   - error: An error if the git command fails or if there are issues accessing the repository
-func (g *GitVCS) CreateCommit(repoPath string, message string, skipHook bool) error {
+func (g *GitVCS) CreateCommit(repoPath string, message string, noVerify bool) error {
 	args := []string{"commit", "-m", message}
-	if skipHook {
+	if noVerify {
 		args = append(args, "--no-verify")
 	}
 	debug.Printf("Creating commit with args: %v", args)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -104,7 +104,7 @@ func TestVCSImplementations(t *testing.T) {
 
 			// Test commit creation
 			t.Run("CreateCommit", func(t *testing.T) {
-				err := vcs.CreateCommit(dir, "test commit")
+				err := vcs.CreateCommit(dir, "test commit", false)
 				require.NoError(t, err)
 
 				// Verify commit success

--- a/internal/git/svn.go
+++ b/internal/git/svn.go
@@ -174,15 +174,10 @@ func (s *SVNVCS) GetLastCommitHash(repoPath string) (string, error) {
 	return s.runCommand(cmd, repoPath)
 }
 
-// CreateCommit creates a SVN commit with the given message
-//
-// Parameters:
-//   - repoPath: The file system path to the SVN repository
-//   - message: The commit message
-//
-// Returns:
-//   - error: An error if the SVN command fails or if there are issues accessing the repository
-func (s *SVNVCS) CreateCommit(repoPath, message string) error {
+// CreateCommit commits changes in the SVN repository with the given message.
+// It uses 'svn commit -m <message>' command.
+// The skipHook parameter is ignored for SVN.
+func (s *SVNVCS) CreateCommit(repoPath, message string, skipHook bool) error {
 	cmd := exec.Command("svn", "commit", "-m", message)
 	_, err := s.runCommand(cmd, repoPath)
 	return err

--- a/internal/git/svn.go
+++ b/internal/git/svn.go
@@ -176,8 +176,8 @@ func (s *SVNVCS) GetLastCommitHash(repoPath string) (string, error) {
 
 // CreateCommit commits changes in the SVN repository with the given message.
 // It uses 'svn commit -m <message>' command.
-// The skipHook parameter is ignored for SVN.
-func (s *SVNVCS) CreateCommit(repoPath, message string, skipHook bool) error {
+// The noVerify parameter is ignored for SVN.
+func (s *SVNVCS) CreateCommit(repoPath, message string, noVerify bool) error {
 	cmd := exec.Command("svn", "commit", "-m", message)
 	_, err := s.runCommand(cmd, repoPath)
 	return err

--- a/internal/git/svn_test.go
+++ b/internal/git/svn_test.go
@@ -95,7 +95,7 @@ func TestSVNVCS(t *testing.T) {
 		assert.Contains(t, files, "test.txt")
 
 		// Create commit
-		err = vcs.CreateCommit(dir, "test commit")
+		err = vcs.CreateCommit(dir, "test commit", false) // skipHook is ignored by SVN
 		require.NoError(t, err)
 
 		// Verify commit
@@ -155,7 +155,7 @@ func TestSVNVCSErrors(t *testing.T) {
 		{
 			name: "CreateCommit error",
 			fn: func() error {
-				return vcs.CreateCommit(invalidDir, "test commit")
+				return vcs.CreateCommit(invalidDir, "test commit", false) // skipHook is ignored by SVN
 			},
 		},
 		{

--- a/internal/git/vcs.go
+++ b/internal/git/vcs.go
@@ -19,7 +19,7 @@ type VCS interface {
 	GetCurrentBranch(repoPath string) (string, error)
 	GetCommitInfo(repoPath, commitHash string) (string, error)
 	GetLastCommitHash(repoPath string) (string, error)
-	CreateCommit(repoPath, message string) error
+	CreateCommit(repoPath, message string, skipHook bool) error
 }
 
 // NewVCS creates a new VCS object based on the given type.

--- a/internal/git/vcs.go
+++ b/internal/git/vcs.go
@@ -19,7 +19,7 @@ type VCS interface {
 	GetCurrentBranch(repoPath string) (string, error)
 	GetCommitInfo(repoPath, commitHash string) (string, error)
 	GetLastCommitHash(repoPath string) (string, error)
-	CreateCommit(repoPath, message string, skipHook bool) error
+	CreateCommit(repoPath, message string, noVerify bool) error
 }
 
 // NewVCS creates a new VCS object based on the given type.

--- a/internal/testutils/mock_vcs.go
+++ b/internal/testutils/mock_vcs.go
@@ -14,8 +14,9 @@ func (m *MockVCS) HasStagedChanges(repoPath string) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockVCS) CreateCommit(repoPath string, message string) error {
-	args := m.Called(repoPath, message)
+// CreateCommit simulates creating a commit, ignoring the skipHook parameter for the mock
+func (m *MockVCS) CreateCommit(repoPath string, message string, skipHook bool) error {
+	args := m.Called(repoPath, message, skipHook)
 	return args.Error(0)
 }
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "2.0.0"
+var version = "2.1.0"
 
 // main is the entry point of the GPTComet application. It initializes and configures the command-line interface
 // using cobra. The following commands are available:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gptcomet"
-version = "2.0.0"
+version = "2.1.0"
 description = "GPTComet: AI-Powered Git Commit Message Generator."
 authors = [{ name = "belingud", email = "im.victor@qq.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "gptcomet"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- **fix: remove unused validation function in ReviewOptions**
- **docs: update README with enhanced project description and features**
- **feat: add skip git hooks verification flag**
- **feat: add skip-hook support for git commits and update flag shorthand**
- **feat: update skip-hook flag description for clarity**
- **feat: rename skipHook parameter to noVerify for consistency in CreateCommit method**
- **test: update CreateCommit noVerify parameter related tests**
- **Bump version: 2.0.0 → 2.1.0**
- **docs: update changelog and readme for v2.1.0**
- **ci: update Ubuntu to 22.04 in release workflow**
